### PR TITLE
Support variant RFC-850 Date Format

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -7,7 +7,7 @@ my class X::DateTime::CannotParse is Exception {
 class DateTime::Parse is DateTime {
     grammar DateTime::Parse::Grammar {
         token TOP {
-            <dt=rfc1123-date> | <dt=rfc850-date> | <dt=asctime-date>
+            <dt=rfc1123-date> | <dt=rfc850-date> | <dt=rfc850-var-date> | <dt=asctime-date>
         }
 
         token rfc1123-date {
@@ -16,6 +16,10 @@ class DateTime::Parse is DateTime {
 
         token rfc850-date {
             <.weekday> ',' <.SP> <date=.date2> <.SP> <time> <.SP> 'GMT'
+        }
+
+        token rfc850-var-date {
+            <.wkday> ','? <.SP> <date=.date4> <.SP> <time> <.SP> 'GMT'
         }
 
         token asctime-date {
@@ -32,6 +36,10 @@ class DateTime::Parse is DateTime {
 
         token date3 { # e.g., Jun  2
             <month> <.SP> (<day=.D2> | <.SP> <day=.D1>)
+        }
+
+        token date4 { # e.g., 02-Jun-1982 
+            <day=.D2> '-' <month> '-' <year=.D4-year>
         }
 
         token time {
@@ -88,16 +96,24 @@ class DateTime::Parse is DateTime {
             make DateTime.new(:year($<year>.made), |$<date>.made, |$<time>.made)
         }
 
-        method date1($/) { # e.g., 02 Jun 1982
+        method !genericDate($/) {
             make { year => $<year>.made, month => $<month>.made, day => $<day>.made }
+        }
+
+        method date1($/) { # e.g., 02 Jun 1982
+            self!genericDate($/);
         }
 
         method date2($/) { # e.g., 02-Jun-82
-            make { year => $<year>.made, month => $<month>.made, day => $<day>.made }
+            self!genericDate($/);
         }
 
         method date3($/) { # e.g., Jun  2
-            make { year => $<year>.made, month => $<month>.made, day => $<day>.made }
+            self!genericDate($/);
+        }
+
+        method date4($/) { # e.g., 02-Jun-1982
+            self!genericDate($/);
         }
 
         method time($/) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,10 +2,13 @@ use v6;
 use Test;
 use DateTime::Parse;
 
-plan 6;
+plan 11;
 
-my $rfc1123 = 'Sun, 06 Nov 1994 08:49:37 GMT';
-my $bad     = 'Bad, 06 Nov 1994 08:49:37 GMT';
+my $rfc1123  = 'Sun, 06 Nov 1994 08:49:37 GMT';
+my $bad      = 'Bad, 06 Nov 1994 08:49:37 GMT';
+my $rfc850   = 'Sunday, 06-Nov-94 08:49:37 GMT';
+my $rfc850v  = 'Sun 06-Nov-1994 08:49:37 GMT';
+my $rfc850vb = 'Sun 06-Nov-94 08:49:37 GMT';
 
 is DateTime::Parse.new('Sun', :rule<wkday>), 6, "'Sun' is day 6 in rule wkday";
 is DateTime::Parse.new('06 Nov 1994', :rule<date1>).sort,
@@ -17,3 +20,8 @@ is DateTime::Parse.new($rfc1123),
    'parse string gives correct DateTime object';
 ok DateTime::Parse::Grammar.parse($rfc1123)<rfc1123-date>, "'Sun, 06 Nov 1994 08:49:37 GMT' is recognized as rfc1123-date";
 throws-like qq[ DateTime::Parse.new('$bad') ], X::DateTime::CannotParse, invalid-str => $bad;
+ok DateTime::Parse::Grammar.parse($rfc850)<rfc850-date>, "'$rfc850' is recognized as rfc850-date";
+nok DateTime::Parse::Grammar.parse($rfc850v)<rfc850-date>, "'$rfc850v' is NOT recognized as rfc850-date";
+ok DateTime::Parse::Grammar.parse($rfc850v)<rfc850-var-date>, "'$rfc850v' is recognized as rfc850-var-date";
+nok DateTime::Parse::Grammar.parse($rfc850)<rfc850-var-date>, "'$rfc850' is NOT recognized as rfc850-var-date";
+nok DateTime::Parse::Grammar.parse($rfc850vb)<rfc850-var-date>, "'$rfc850vb' is NOT recognized as rfc850-var-date";


### PR DESCRIPTION
Adds support for a variant date format to the RFC-850 version already included. This format is used by IIS.NET servers.

Tests included to insure that the new rule does not conflict with the existing one.