### PR TITLE
Fix asctime

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -260,3 +260,5 @@ Website: filip.sergot.pl
 Contact: filip (at) sergot.pl
 
 =end pod
+
+# vim: et sw=4 ts=4

--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -62,7 +62,7 @@ class DateTime::Parse is DateTime {
         }
 
         token date3 { # e.g., Jun  2
-            <month> <.SP> (<day=.D2> | <.SP> <day=.D1>)
+            <month> <.SP> <day>
         }
 
         token date4 { # e.g., 02-Jun-1982 
@@ -71,6 +71,10 @@ class DateTime::Parse is DateTime {
 
         token time {
             <hour=.D2> ':' <minute=.D2> ':' <second=.D2>
+        }
+
+        token day {
+            <.D1> | <.D2>
         }
 
         token wkday {
@@ -94,7 +98,7 @@ class DateTime::Parse is DateTime {
         }
 
         token SP {
-            \s
+            \s+
         }
 
         token D1 {
@@ -128,7 +132,10 @@ class DateTime::Parse is DateTime {
         }
 
         method asctime-date($/) {
-            make DateTime.new(:year($<year>.made), |$<date>.made, |$<time>.made)
+            my $date = $<date>.made;
+            $date<year> = $<year>.made;
+
+            make DateTime.new(|$<date>.made, |$<time>.made)
         }
 
         method !genericDate($/) {
@@ -187,6 +194,10 @@ class DateTime::Parse is DateTime {
                     Jul => 7, Aug => 8, Sep => 9, Oct => 10, Nov => 11, Dec => 12;
         method month($/) {
             make %month{~$/}
+        }
+
+        method day($/) {
+            make +$/
         }
 
         method D4-year($/) {

--- a/t/01-asctime.t
+++ b/t/01-asctime.t
@@ -5,10 +5,35 @@ use v6.c;
 use DateTime::Parse;
 use Test;
 
+
 plan 1;
 
-my $string = "Thu Mar  3 23:05:25 2005";
+subtest "date(1) strings" => {
+	my @asctimes = (
+		"Fri Mar 23 13:20:46 2018",
+		"Thu Mar  3 23:05:25 2005",
+	);
 
-lives-ok { DateTime::Parse.new($string); }, "date(1) string can be parsed";
+	plan @asctimes.elems + 1;
+
+	for @asctimes {
+		lives-ok { DateTime::Parse.new($_); }, "$_ parses";
+	}
+
+	subtest "Thu Mar  3 23:05:25 2005 parses correctly" => {
+		my $dt = DateTime::Parse.new("Thu Mar  3 23:05:25 2005");
+
+		plan 7;
+
+		isa-ok $dt, DateTime, "Returns a DateTime object";
+
+		is $dt.year, 2005, "Year is correct";
+		is $dt.month, 3, "Month is correct";
+		is $dt.day, 3, "Day is correct";
+		is $dt.hour, 23, "Hour is correct";
+		is $dt.minute, 5, "Minute is correct";
+		is $dt.second, 25, "Second is correct";
+	}
+}
 
 # vim: ft=perl6 noet

--- a/t/01-asctime.t
+++ b/t/01-asctime.t
@@ -6,7 +6,7 @@ use DateTime::Parse;
 use Test;
 
 
-plan 1;
+plan 2;
 
 subtest "date(1) strings" => {
 	my @asctimes = (
@@ -33,6 +33,55 @@ subtest "date(1) strings" => {
 		is $dt.hour, 23, "Hour is correct";
 		is $dt.minute, 5, "Minute is correct";
 		is $dt.second, 25, "Second is correct";
+	}
+}
+
+subtest "locale datetime string with timezone" => {
+	my @asctimes = (
+		"Fri Mar 23 13:20:46 2018 UTC",
+		"Fri Mar 23 13:20:46 2018 UTC+3",
+	);
+
+	plan @asctimes.elems + 2;
+
+	for @asctimes {
+		lives-ok { DateTime::Parse.new($_); }, "$_ parses";
+	}
+
+	subtest "Fri Mar 23 13:20:46 2018 UTC parses correctly" => {
+		my $dt = DateTime::Parse.new("Fri Mar 23 13:20:46 2018 UTC");
+
+		plan 7;
+
+		isa-ok $dt, DateTime, "Returns a DateTime object";
+
+		is $dt.year, 2018, "Year is correct";
+		is $dt.month, 3, "Month is correct";
+		is $dt.day, 23, "Day is correct";
+		is $dt.hour, 13, "Hour is correct";
+		is $dt.minute, 20, "Minute is correct";
+		is $dt.second, 46, "Second is correct";
+	}
+
+	subtest "Fri Mar 23 13:20:46 2018 UTC+3 parses correctly" => {
+		my $dt = DateTime::Parse.new("Fri Mar 23 13:20:46 2018 UTC+3");
+
+		plan 10;
+
+		isa-ok $dt, DateTime, "Returns a DateTime object";
+		is $dt.offset-in-hours, 3, "Offset is 3 hours";
+
+		$dt .= utc;
+
+		isa-ok $dt, DateTime, "Still a DateTime after converting to UTC";
+		is $dt.offset-in-hours, 0, "Offset is now 0 hours";
+
+		is $dt.year, 2018, "Year is correct";
+		is $dt.month, 3, "Month is correct";
+		is $dt.day, 23, "Day is correct";
+		is $dt.hour, 10, "Hour is correct";
+		is $dt.minute, 20, "Minute is correct";
+		is $dt.second, 46, "Second is correct";
 	}
 }
 

--- a/t/01-asctime.t
+++ b/t/01-asctime.t
@@ -1,0 +1,14 @@
+#! /usr/bin/env perl6
+
+use v6.c;
+
+use DateTime::Parse;
+use Test;
+
+plan 1;
+
+my $string = "Thu Mar  3 23:05:25 2005";
+
+lives-ok { DateTime::Parse.new($string); }, "date(1) string can be parsed";
+
+# vim: ft=perl6 noet


### PR DESCRIPTION
The `asctime` format was not included in the test suite, and was failing for me on `"Fri Mar 23 13:20:46 2018 UTC"`. I added a test case for the regular `asctime` format as it was intended (assuming from the codebase, that is), and another test case to include my personal issue of the additional timezone.