### PR TITLE
Improve RFC 3339 support

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"      : "6.*",
     "name"      : "DateTime::Parse",
-    "version"   : "0.9",
+    "version"   : "0.9.1",
     "description"   : "DateTime parser",
     "build-depends" : [ ],
     "test-depends" : [

--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -161,7 +161,7 @@ class DateTime::Parse is DateTime {
 
         method time2($/) {
             my $p = $<part>;
-            my $offset;
+            my $offset = 0;
             unless $<offset> eq 'Z'|'z' {
                 if ~$<offset><offset><sign> eq '-' {
                     $offset = 3600 * ~$<offset><offset><hour>.Int;

--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -10,7 +10,7 @@ class DateTime::Parse is DateTime {
         }
 
         token rfc3339-date {
-            <date=.date5> 'T' <time=.time2>
+            <date=.date5> <[Tt \x0020]> <time=.time2>
         }
 
         token date5 {
@@ -30,7 +30,7 @@ class DateTime::Parse is DateTime {
         }
 
         token time-offset {
-            [ 'Z' | <offset=.time-numoffset>]
+            [ 'Z' | 'z' | <offset=.time-numoffset>]
         }
 
         token time-numoffset {

--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -162,7 +162,7 @@ class DateTime::Parse is DateTime {
         method time2($/) {
             my $p = $<part>;
             my $offset;
-            unless $<offset> eq 'Z' {
+            unless $<offset> eq 'Z'|'z' {
                 if ~$<offset><offset><sign> eq '-' {
                     $offset = 3600 * ~$<offset><offset><hour>.Int;
                     $offset += 60 * ~$<offset><offset><minute>.Int;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -30,4 +30,14 @@ nok DateTime::Parse::Grammar.parse($rfc850vb)<rfc850-var-date>, "'$rfc850vb' is 
 ok DateTime::Parse::Grammar.parse($rfc3339_1)<rfc3339-date>, "'$rfc3339_1' is recognized as rfc3339-date";
 ok DateTime::Parse::Grammar.parse($rfc3339_2)<rfc3339-date>, "'$rfc3339_2' is recognized as rfc3339-date";
 
+# RFC 3339 additional tests
+subtest {
+    ok DateTime::Parse::Grammar.parse("1994-11-06 08:49:37Z")<rfc3339-date>;
+    ok DateTime::Parse::Grammar.parse("1994-11-06T08:49:37Z")<rfc3339-date>;
+    ok DateTime::Parse::Grammar.parse("1994-11-06t08:49:37Z")<rfc3339-date>;
+    ok DateTime::Parse::Grammar.parse("1994-11-06 08:49:37z")<rfc3339-date>;
+    ok DateTime::Parse::Grammar.parse("1994-11-06T08:49:37z")<rfc3339-date>;
+    ok DateTime::Parse::Grammar.parse("1994-11-06t08:49:37z")<rfc3339-date>;
+}, 'RFC 3339 formatted time is case-insensitive';
+
 done-testing;


### PR DESCRIPTION
RFC allows less strict grammar, so we'd like to recognize "not so strict" versions too.