### PR TITLE
Add tokens for Nginx timestamps

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -6,19 +6,23 @@ my class X::DateTime::CannotParse is Exception {
 class DateTime::Parse is DateTime {
     grammar DateTime::Parse::Grammar {
         token TOP {
-            <dt=rfc3339-date> | <dt=rfc1123-date> | <dt=rfc850-date> | <dt=rfc850-var-date> | <dt=asctime-date>
+            <dt=rfc3339-date> | <dt=rfc1123-date> | <dt=rfc850-date> | <dt=rfc850-var-date> | <dt=asctime-date> | <dt=nginx-date>
         }
 
         token rfc3339-date {
             <date=.date5> <[Tt \x0020]> <time=.time2>
         }
 
-        token date5 {
-            <year=.D4-year>  '-' <month=.D2> '-' <day=.D2>
+        token nginx-date {
+            <date=.date6> ':' <time=.time3>
         }
 
         token time2 {
             <part=.partial-time> <offset=.time-offset>
+        }
+
+        token time3 {
+            <time=.partial-time> ' ' <time-numoffset>
         }
 
         token partial-time {
@@ -34,7 +38,7 @@ class DateTime::Parse is DateTime {
         }
 
         token time-numoffset {
-            <sign=[+-]> <hour=.D2> ':' <minute=.D2>
+            <sign=[+-]> <hour=.D2> ':'? <minute=.D2>
         }
 
         token time-houroffset {
@@ -83,6 +87,14 @@ class DateTime::Parse is DateTime {
 
         token date4 { # e.g., 02-Jun-1982 
             <day=.D2> '-' <month> '-' <year=.D4-year>
+        }
+
+        token date5 {
+            <year=.D4-year>  '-' <month=.D2> '-' <day=.D2>
+        }
+
+        token date6 {
+            <day=.D2> '/' <month> '/' <year=.D4-year>
         }
 
         token time {
@@ -156,6 +168,10 @@ class DateTime::Parse is DateTime {
             make DateTime.new(|$<date>.made, |$<time>.made, :timezone($tz))
         }
 
+        method nginx-date($/) {
+            make DateTime.new(|$<date>.made, |$<time>.made);
+        }
+
         method !genericDate($/) {
             make { year => $<year>.made, month => $<month>.made, day => $<day>.made }
         }
@@ -177,6 +193,10 @@ class DateTime::Parse is DateTime {
         }
 
         method date5($/) { # e.g. 1996-12-19
+            self!genericDate($/);
+        }
+
+        method date6($/) { # e.g. 28/Mar/2018
             self!genericDate($/);
         }
 
@@ -214,6 +234,20 @@ class DateTime::Parse is DateTime {
             }
             my %res = hour => ~$p<hour>, minute => ~$p<minute>, second => ~$p<second>, timezone => -$offset;
             make %res;
+        }
+
+        method time3($/) {
+            my Int $offset = 0;
+
+            $offset += +$<time-numoffset><hour> × 60;
+            $offset += +$<time-numoffset><minute>;
+
+            make {
+                hour     => +$<time><hour>,
+                minute   => +$<time><minute>,
+                second   => +$<time><second>,
+                timezone => $offset,
+            };
         }
 
         my %wkday = Mon => 0, Tue => 1, Wed => 2, Thu => 3, Fri => 4, Sat => 5, Sun => 6;

--- a/t/01-nginx-accesslog-timestamps.t
+++ b/t/01-nginx-accesslog-timestamps.t
@@ -1,0 +1,39 @@
+#! /usr/bin/env perl6
+
+use v6.c;
+
+use DateTime::Parse;
+use Test;
+
+my @timestamps = «
+	"28/Mar/2018:10:20:01 +0000"
+	"28/Mar/2018:10:20:04 +0000"
+	"28/Mar/2018:10:20:07 +0000"
+	"28/Mar/2018:10:20:09 +0000"
+	"28/Mar/2018:10:20:51 +0000"
+	"28/Mar/2018:10:21:15 +0200"
+	"28/Mar/2018:10:21:17 +0030"
+»;
+
+plan @timestamps.elems + 1;
+
+for @timestamps {
+	lives-ok { DateTime::Parse.new($_); }, "$_ parses";
+}
+
+subtest "28/Mar/2018:10:21:17 +0000 parses correctly" => {
+	my $dt = DateTime::Parse.new("28/Mar/2018:10:21:17 +0000");
+
+	plan 7;
+
+	isa-ok $dt, DateTime, "Returns a DateTime object";
+
+	is $dt.year, 2018, "Year is correct";
+	is $dt.month, 3, "Month is correct";
+	is $dt.day, 28, "Day is correct";
+	is $dt.hour, 10, "Hour is correct";
+	is $dt.minute, 21, "Minute is correct";
+	is $dt.second, 17, "Second is correct";
+}
+
+# vim: ft=perl6 noet


### PR DESCRIPTION
These are the timestamps used by default in the nginx access logs.