### PR TITLE
Updated Parse.pm6

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -44,17 +44,21 @@ class DateTime::Parse is DateTime {
         token hour {
             \d \d?
         }
+        
+        token gmtUtc {
+          'GMT' | 'UTC'
+        }
 
         token rfc1123-date {
-            <.wkday> ',' <.SP> <date=.date1> <.SP> <time> <.SP> 'GMT'
+            <.wkday> ',' <.SP> <date=.date1> <.SP> <time> <.SP> <utcGmt>
         }
 
         token rfc850-date {
-            <.weekday> ',' <.SP> <date=.date2> <.SP> <time> <.SP> 'GMT'
+            <.weekday> ',' <.SP> <date=.date2> <.SP> <time> <.SP> <gmtUtc>
         }
 
         token rfc850-var-date {
-            <.wkday> ','? <.SP> <date=.date4> <.SP> <time> <.SP> 'GMT'
+            <.wkday> ','? <.SP> <date=.date4> <.SP> <time> <.SP> <gmtUtc>
         }
 
         token asctime-date {

--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -50,7 +50,7 @@ class DateTime::Parse is DateTime {
         }
 
         token rfc1123-date {
-            <.wkday> ',' <.SP> <date=.date1> <.SP> <time> <.SP> <utcGmt>
+            <.wkday> ',' <.SP> <date=.date1> <.SP> <time> <.SP> <gmtUtc>
         }
 
         token rfc850-date {


### PR DESCRIPTION
This allows either 'GMT' OR 'UTC' in all RFC time formats.