### PR TITLE
Add rfc850-var-date-two token

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -6,7 +6,7 @@ my class X::DateTime::CannotParse is Exception {
 class DateTime::Parse is DateTime {
     grammar DateTime::Parse::Grammar {
         token TOP {
-            <dt=rfc3339-date> | <dt=rfc1123-date> | <dt=rfc850-date> | <dt=rfc850-var-date> | <dt=asctime-date>
+            <dt=rfc3339-date> | <dt=rfc1123-date> | <dt=rfc850-date> | <dt=rfc850-var-date> | <dt=rfc850-var-date-two> | <dt=asctime-date>
         }
 
         token rfc3339-date {
@@ -44,7 +44,7 @@ class DateTime::Parse is DateTime {
         token hour {
             \d \d?
         }
-        
+
         token gmtUtc {
           'GMT' | 'UTC'
         }
@@ -59,6 +59,10 @@ class DateTime::Parse is DateTime {
 
         token rfc850-var-date {
             <.wkday> ','? <.SP> <date=.date4> <.SP> <time> <.SP> <gmtUtc>
+        }
+
+        token rfc850-var-date-two {
+            <.wkday> ','? <.SP> <date=.date2> <.SP> <time> <.SP> <gmtUtc>
         }
 
         token asctime-date {
@@ -85,7 +89,7 @@ class DateTime::Parse is DateTime {
             <month> <.SP> <day>
         }
 
-        token date4 { # e.g., 02-Jun-1982 
+        token date4 { # e.g., 02-Jun-1982
             <day=.D2> '-' <month> '-' <year=.D4-year>
         }
 
@@ -148,6 +152,10 @@ class DateTime::Parse is DateTime {
         }
 
         method rfc850-var-date($/) {
+            make DateTime.new(|$<date>.made, |$<time>.made)
+        }
+
+        method rfc850-var-date-two($/) {
             make DateTime.new(|$<date>.made, |$<time>.made)
         }
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -24,9 +24,13 @@ ok DateTime::Parse::Grammar.parse($rfc1123)<rfc1123-date>, "'Sun, 06 Nov 1994 08
 throws-like qq[ DateTime::Parse.new('$bad') ], X::DateTime::CannotParse, invalid-str => $bad;
 ok DateTime::Parse::Grammar.parse($rfc850)<rfc850-date>, "'$rfc850' is recognized as rfc850-date";
 nok DateTime::Parse::Grammar.parse($rfc850v)<rfc850-date>, "'$rfc850v' is NOT recognized as rfc850-date";
-ok DateTime::Parse::Grammar.parse($rfc850v)<rfc850-var-date>, "'$rfc850v' is recognized as rfc850-var-date";
+nok DateTime::Parse::Grammar.parse($rfc850vb)<rfc850-date>, "'$rfc850vb' is NOT recognized as rfc850-date";
 nok DateTime::Parse::Grammar.parse($rfc850)<rfc850-var-date>, "'$rfc850' is NOT recognized as rfc850-var-date";
+ok DateTime::Parse::Grammar.parse($rfc850v)<rfc850-var-date>, "'$rfc850v' is recognized as rfc850-var-date";
 nok DateTime::Parse::Grammar.parse($rfc850vb)<rfc850-var-date>, "'$rfc850vb' is NOT recognized as rfc850-var-date";
+nok DateTime::Parse::Grammar.parse($rfc850)<rfc850-var-date-two>, "'$rfc850' is NOT recognized as rfc850-var-date-two";
+nok DateTime::Parse::Grammar.parse($rfc850v)<rfc850-var-date-two>, "'$rfc850v' is NOT recognized as rfc850-var-date-two";
+ok DateTime::Parse::Grammar.parse($rfc850vb)<rfc850-var-date-two>, "'$rfc850vb' is recognized as rfc850-var-date-two";
 ok DateTime::Parse::Grammar.parse($rfc3339_1)<rfc3339-date>, "'$rfc3339_1' is recognized as rfc3339-date";
 ok DateTime::Parse::Grammar.parse($rfc3339_2)<rfc3339-date>, "'$rfc3339_2' is recognized as rfc3339-date";
 


### PR DESCRIPTION
This date format is used in CloudFlare's __cfduid cookie's Expires
field, which is causing Cro::HTTP::Client not to be able to match their
cookies with this grammar.