### PR TITLE
Fix rfc3339 fractional seconds

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -26,7 +26,7 @@ class DateTime::Parse is DateTime {
         }
 
         token time-secfrac {
-            '.' \d ** 1..3
+            '.' \d+
         }
 
         token time-offset {


### PR DESCRIPTION
The spec says `1*DIGIT` which means "at least one". So don't limit to three digits.
This makes is possible to parse the output of `DateTime.now`.