### PR TITLE
Support +/- 0000 for GMT

### DIFF
--- a/lib/DateTime/Parse.pm6
+++ b/lib/DateTime/Parse.pm6
@@ -46,7 +46,7 @@ class DateTime::Parse is DateTime {
         }
 
         token gmtUtc {
-          'GMT' | 'UTC'
+          'GMT' | 'UTC' | [ <[-+]>? '0000' ]
         }
 
         token rfc1123-date {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -44,4 +44,7 @@ subtest {
     ok DateTime::Parse::Grammar.parse("1994-11-06t08:49:37z")<rfc3339-date>;
 }, 'RFC 3339 formatted time is case-insensitive';
 
+# -0000 for UTC
+ok DateTime::Parse::Grammar.parse('Wed, 26 Feb 2020 21:38:40 -0000')<rfc1123-date>, 'numeric gmt value';
+
 done-testing;


### PR DESCRIPTION
Hi!

The values `-0000` and `+0000` are valid according to [RFC 822](https://tools.ietf.org/html/rfc822#section-5) and the other specs that reference it.  Would it be possible to support  this as an equivalent way of writing "GMT" or "UTC"?

thanks!
Brian
